### PR TITLE
Add csvtodashboard to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Here are some awesome tools for dealing with CSV:
 - [CSVGet](http://github.com/fizx/csvget/tree/master) - Get structured data from sites as CSV.
 - [CSVfix](https://code.google.com/p/csvfix/) - A tool for manipulating CSV data.
 - [Tad](https://www.tadviewer.com) - A fast free cross-platform CSV viewer.
+- [csvtodashboard](https://csvtodashboard.com) - Convert, clean, query (SQL) and visualize CSV entirely in the browser - local-first, nothing is uploaded.
 - [Nvd3-tags](http://blog.tryolabs.com/2015/02/27/nvd3-tags-a-tiny-library-for-making-charts-from-csv-data/) - A tiny library for making charts from csv data.
 - [Powershell: Import-CSV](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/import-csv) - Powerful in-built facility for dealing with CSV ([example](https://gist.github.com/dfinke/786ba9edae1b0265ada10b36a7a11ba9)).
 - [CSV Tools](https://onlinecsvtools.com/) - A collection of useful CSV utilities.


### PR DESCRIPTION
Adding [csvtodashboard](https://csvtodashboard.com) to the Tools section.

Full disclosure: I built it. It's a free, ad-supported collection of CSV tools (converters, cleaning, SQL querying, dashboards/charts) that runs entirely client-side - files are parsed in the browser and never uploaded, which also lets it open 100 MB+ files without a server round-trip.

Formatted to match the existing entries; happy to amend wording or placement if you'd prefer it elsewhere.