### PR TITLE
Add Marbella Price Data to Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Here are some awesome tools for dealing with CSV:
 - [Reference data in csv](https://datahub.io/collections/reference-data) - Easy-to-use reference data in CSV and JSON formats.
 - [awesome-public-datasets](https://github.com/awesomedata/awesome-public-datasets) - A topic-centric list of high-quality open datasets in public domains.
 - [United Nations data](https://data.un.org) - Data from the UN
+- [Marbella Price Data](https://github.com/shiftdylson1/marbella-price-data) - Sunbed, chiringuito and beach club prices for Marbella, Spain, season 2026, in CSV (+ JSON), with per-venue provenance and a DOI.
 
 ## Conferences
 


### PR DESCRIPTION
Adds a small, single-purpose open dataset (as opposed to the portals already listed): sunbed, chiringuito and beach club prices for Marbella, Spain, season 2026, published as CSV (+ JSON) at https://github.com/shiftdylson1/marbella-price-data - sourced from each venue's own posted menu with provenance notes, not scraped guesses. DOI via Zenodo, CC BY 4.0. Happy to close if the list prefers to stay portal-only.